### PR TITLE
Update strong ice wave.lua

### DIFF
--- a/data/spells/scripts/attack/strong ice wave.lua
+++ b/data/spells/scripts/attack/strong ice wave.lua
@@ -3,7 +3,7 @@ setCombatParam(combat, COMBAT_PARAM_TYPE, COMBAT_ICEDAMAGE)
 setCombatParam(combat, COMBAT_PARAM_EFFECT, CONST_ME_ICEATTACK)
 setCombatFormula(combat, COMBAT_FORMULA_LEVELMAGIC, -1.0, 0, -1.5, 0)
 
-local area = createCombatArea(AREA_WAVE4, AREADIAGONAL_WAVE4)
+local area = createCombatArea(AREA_WAVE5, AREADIAGONAL_WAVE5)
 setCombatArea(combat, area)
 
 function onCastSpell(cid, var)


### PR DESCRIPTION
Bug fix: http://otland.net/threads/best-released-real-map-10-31-based-1-0.204514/page-29#post-1986125 

Changed area from 4 to 5. 
Source: http://tibia.wikia.com/wiki/Strong_Ice_Wave
Reason: "This spell has the same cooldown, manacost and damage formula as the Sorcerer's Energy Wave."
