### PR TITLE
Update Loot of Energy Elemental

### DIFF
--- a/data/monster/Electro-Elementals/energy elemental.xml
+++ b/data/monster/Electro-Elementals/energy elemental.xml
@@ -53,7 +53,7 @@
 		<item id="2148" countmax="100" chance="50000"/><!-- gold coin -->
 		<item id="2148" countmax="70" chance="50000"/><!-- gold coin -->
 		<item id="7620" chance="11711"/><!-- mana potion -->
-		<item id="7638" countmax="10" chance="10000"/><!-- flash arrow -->
+		<item id="7838" countmax="10" chance="10000"/><!-- flash arrow -->
 		<item id="2399" countmax="5" chance="9900"/><!-- throwing star -->
 		<item id="7589" chance="7692"/><!-- strong mana potion -->
 		<item id="7449" chance="5882"/><!-- crystal sword -->


### PR DESCRIPTION
Energy Elemental was giving a dead cat. Wrong id number of Flash Arrow
