### PR TITLE
fix bug?

### DIFF
--- a/data/actions/scripts/quests/system.lua
+++ b/data/actions/scripts/quests/system.lua
@@ -29,6 +29,7 @@ function onUse(cid, item, fromPosition, itemEx, toPosition)
 
 	if(item.actionid == 2215 and getPlayerStorageValue(cid, 2215) < 1) then --anni
 		doPlayerAddExp(cid, 100000, true, true)
+		setPlayerStorageValue(cid,2215, 1) 
 	end
 	if(item.uid == 9170 and getPlayerStorageValue(cid, 9170) < 1) then --banshee
 		doPlayerAddExp(cid, 20000, true, true)


### PR DESCRIPTION
Made pull request since if I am not wrong this is major bug.
Example this;
    if(item.actionid == 2215 and getPlayerStorageValue(cid, 2215) < 1) then --anni
        doPlayerAddExp(cid, 100000, true, true)
    end

Bottom of the file;
        result = "You have found " .. result .. "."
        setPlayerStorageValue(cid, storage, 1)
    end

Because right now = player doesn't have cap or room in his backpack hes storage id won't become (2215, 1) correct?  = he will get the experience from the chest as many times as he wants.

Ofc, by adding setPlayerStorageValue(cid,2215, 1)  to the file would be "quick fix", but not a proper one.

Well.. or just add the "addExp" here.
    else
        result = "You have found " .. result .. "."
        setPlayerStorageValue(cid, storage, 1)
            doPlayerAddExp(uhm, became more difficult than thought) 
    end
