### PR TITLE
Check this out.

### DIFF
--- a/data/actions/scripts/quests/system.lua
+++ b/data/actions/scripts/quests/system.lua
@@ -18,7 +18,7 @@ function onUse(cid, item, fromPosition, itemEx, toPosition)
 	if(item.uid == 1296) then --behemoth quest
 		if (getPlayerStorageValue(cid, 9244) < 1) then
 			doPlayerAddExp(cid, 80000, true, true)
-			setPlayerStorageValue(cid,9244, 1) 
+			setPlayerStorageValue(cid,9244, 1)
 		end
 	end
  


### PR DESCRIPTION
I am not sure what happened but I just ment to merge "system.lua"
## Please read this before merging it.

Last time I made a pull request and didn't fix all the bugs there properly because I wanted somebody else to take a look.
Well, I have fixed the other "exp bugs" there now, so you might as well merge this if you don't have time to figure it out how it should would work with tables.
//After this commit players can't abuse the reward chest if they don't have cap or room in backpacks.
Anyway line 121-124~
    else
        result = "You have found " .. result .. "."
        setPlayerStorageValue(cid, storage, 1)
    end

I think that it would be better to add "exp storage ID" there too and make tables for experience rewards.

I am not very good with tables, therefore I won't even give it a try since I can't figure out how it should work.
