### PR TITLE
Update Mission1WhisperMossDoorReward.lua

### DIFF
--- a/data/actions/scripts/the ape city/Mission1WhisperMossDoorReward.lua
+++ b/data/actions/scripts/the ape city/Mission1WhisperMossDoorReward.lua
@@ -18,7 +18,7 @@ end
 and this is the Mission1WhisperMossReward.lua
 
 function onUse(cid, item, fromPosition, itemEx, toPosition)
-	if item.uniqueid == 12121 then
+	if item.uid == 12121 then
 	local player = Player(cid)
 		if item.itemid == 1738 then --chest reward
 			if player:getStorageValue(12121) == 1 then


### PR DESCRIPTION
I've separated the door/reward funcions.
the motive is simple, if you use an actionid in a chest you can move it to anyway....
if you use uniqueid it will be unamoveable item.
