### PR TITLE
Update inquisitionQuestRewards.lua

### DIFF
--- a/data/actions/scripts/inquisition quest/inquisitionQuestRewards.lua
+++ b/data/actions/scripts/inquisition quest/inquisitionQuestRewards.lua
@@ -16,12 +16,9 @@ function onUse(cid, item, fromPosition, itemEx, toPosition)
 		Player(cid):setStorageValue(200, 25)
 		Player(cid):setStorageValue(12117, 5) -- The Inquisition Questlog- "Mission 7: The Shadow Nexus"
 		doPlayerAddItem(cid, rewards[item.uid], 1)
-		doTeleportThing(cid, {x = 32317, y = 32261, z = 9})
 		doPlayerSendTextMessage(cid, MESSAGE_INFO_DESCR, "You've found " .. getItemName(rewards[item.uid]) .. ".")
-		doPlayerAddExp(cid, 1000000, true, true)
 	else
 		doPlayerSendTextMessage(cid, MESSAGE_INFO_DESCR, "The chest is empty.")
-		doTeleportThing(cid, {x = 32317, y = 32261, z = 9})
 	end
 	return true
 end


### PR DESCRIPTION
in real tibia won't teleport you to exit, and if someone want a real tibia project fidel to real gamming, real tibia won't get exp to get the reward
