### PR TITLE
Update pitsOfInfernoQuestWalls.lua

### DIFF
--- a/data/actions/scripts/pits of inferno quest/pitsOfInfernoQuestWalls.lua
+++ b/data/actions/scripts/pits of inferno quest/pitsOfInfernoQuestWalls.lua
@@ -8,10 +8,11 @@ local pos = {
 function onUse(cid, item, fromPosition, itemEx, toPosition)
 	if(item.itemid == 1945) then
 		doRemoveItem(getTileItemById(pos[item.uid], 6289).uid, 1)
-		doSendMagicEffect(pos[item.uid], CONST_ME_FIRE)
+		doRemoveItem(getTileItemById(pos[item.uid], 6289).uid, 1)
+		doSendMagicEffect(pos[item.uid], CONST_ME_FIREATTACK)
 	else
 		doCreateItem(6289, 1, pos[item.uid])
-		doSendMagicEffect(pos[item.uid], CONST_ME_FIRE)
+		doSendMagicEffect(pos[item.uid], CONST_ME_FIREATTACK)
 	end
 	
 	if (item.itemid == 1945) then


### PR DESCRIPTION
why i've duplicated the removeItem?
it's simple, if my wallbacks from levers poll is accepted that must be accepted too, if you have the fire wall in flames and the levers script make appear another fire in flames, when you pull the lever it only will delete 1, but if you duplicate that action it don't appear and all fixed :D
