### PR TITLE
Change quest to work like "RL"

### DIFF
--- a/data/actions/scripts/gravedigger quest/brain.lua
+++ b/data/actions/scripts/gravedigger quest/brain.lua
@@ -1,11 +1,14 @@
 function onUse(cid, item, fromPosition, itemEx, toPosition)
+	local rightbrain = Tile(Position(33025, 32332, 10))
+	local leftbrain = Tile(Position(33020, 32332, 10))
 	local player = Player(cid)
 	if player:getStorageValue(9998) == 1 and player:getStorageValue(9999) < 1 then
-		if player:getItemCount(10576) >= 2 then
+		if leftbrain:getItemById(10576) and rightbrain:getItemById(10576) then
 			player:setStorageValue(9999, 1)
 			player:sendTextMessage(MESSAGE_EVENT_ADVANCE, '<brzzl> <frzzp> <fsssh>')
-			player:addItem(21395, 1)
-			player:removeItem(10576, 2)
+			leftbrain:getItemById(10576):remove()
+			rightbrain:getItemById(10576):remove()
+			Game.createItem(21395, 1, Position(33022, 32332, 10))
 		else
 			player:sendTextMessage(MESSAGE_EVENT_ADVANCE, 'No brains')
 		end


### PR DESCRIPTION
#763

Still need to:

```
1. move the stone
2. delete what is under the sacrificial stone
3. make sure you are able to select the "empty pipe"
4. move the sacrificial stone back
```

So it is possible to place the brain on the sacrificial stone

--Note: might be good to wait with merging until it is possible to place the brain on the altar?
