### PR TITLE
Increased timer interval of noxiousClaw curse

### DIFF
--- a/data/actions/scripts/tools/noxiousclaw.lua
+++ b/data/actions/scripts/tools/noxiousclaw.lua
@@ -3,7 +3,7 @@ cursed:setParameter(CONDITION_PARAM_DELAYED, true) -- Condition will delay the f
 cursed:setParameter(CONDITION_PARAM_MINVALUE, -800) -- Minimum damage the condition can do at total
 cursed:setParameter(CONDITION_PARAM_MAXVALUE, -1200) -- Maximum damage
 cursed:setParameter(CONDITION_PARAM_STARTVALUE, -1) -- The damage the condition will do on the first hit
-cursed:setParameter(CONDITION_PARAM_TICKINTERVAL, 4000) -- Delay between damages
+cursed:setParameter(CONDITION_PARAM_TICKINTERVAL, 40000) -- Delay between damages
 cursed:setParameter(CONDITION_PARAM_FORCEUPDATE, true) -- Re-update condition when adding it(ie. min/max value)
 
 function onUse(cid, item, fromPosition, itemEx, toPosition)


### PR DESCRIPTION
Increased the TICKINTERVAL due to the player was receiving damage too often once getting cursed, and it ticked for 1 dmg on every tick, should change dmg on each tick.
